### PR TITLE
fix: Token state should be checked only for implicit grant type

### DIFF
--- a/src/Oauth2MethodMixin.js
+++ b/src/Oauth2MethodMixin.js
@@ -499,7 +499,7 @@ const mxFunction = (base) => {
         if (!tokenInfo) {
           return null;
         }
-        if (tokenInfo.state !== state) {
+        if (detail.grantType === 'implicit' && tokenInfo.state !== state) {
           return null;
         }
         if (tokenInfo.accessToken && tokenInfo.accessToken !== this.accessToken) {


### PR DESCRIPTION
During the manual testing, I found out that `password` and `client_credentials` grant types fail silently when attempting to request an access token via the request panel. This is due to the `/token` endpoint not including the `state` property in the response and this check seems to be only specific to the `implicit` grant type, which uses only the `/authorize` endpoint.

This check seems to be redundant, since the state is already checked during the authorization event here https://github.com/advanced-rest-client/oauth-authorization/blob/stage/src/OAuth2Authorization.js#L411, but tests are failing in this case.